### PR TITLE
Base panel and intro section responsiveness

### DIFF
--- a/apps/main/app/sections/ContentPanels.tsx
+++ b/apps/main/app/sections/ContentPanels.tsx
@@ -58,17 +58,43 @@ export default function ContentPanels() {
     window.scrollBy({ top: window.innerHeight, left: 0, behavior: "smooth" })
   }
 
-  const LearnSimple = () => (
-    <Box
-      id="learn-simple"
+  interface ContentPanelProps {
+    id: string
+    smallScreenFlexDir?: 'column' | 'column-reverse' | 'row' | 'row-reverse'
+    smallScreenAlign?: 'flex-start' | 'center' | 'flex-end'
+    largeScreenFlexDir?: 'column' | 'column-reverse' | 'row' | 'row-reverse'
+    largeScreenAlign?: 'flex-start' | 'center' | 'flex-end'
+    children: React.ReactNode
+  }
+
+  function ContentPanel({
+    id,
+    smallScreenFlexDir = 'column',
+    largeScreenFlexDir = 'row',
+    smallScreenAlign = 'flex-start',
+    largeScreenAlign = 'center',
+    children
+  }: ContentPanelProps) {
+    return (<Box
+      id={id}
       sx={{
         display: "flex",
-        alignItems: { sm: "flex-start", lg: "center" },
-        flexDirection: { sm: "column-reverse", lg: "row" },
+        alignItems: { sm: smallScreenAlign, lg: largeScreenAlign },
+        flexDirection: { sm: smallScreenFlexDir, lg: largeScreenFlexDir },
         gap: (theme) => theme.layout.spacing.md,
         color: (theme) => theme.palette.blue.darkest,
         width: "100%",
+        paddingTop: { xs: 3, md: 14 },
       }}
+    >
+      {children}
+    </Box>)
+  }
+
+  const LearnSimple = () => (
+    <ContentPanel
+      id="learn"
+      smallScreenFlexDir="column-reverse"
     >
       {/* Text column */}
       <Box sx={{ flex: 1, minWidth: 0 }}>
@@ -94,20 +120,12 @@ export default function ContentPanels() {
           sx={{ width: "100%", maxWidth: 520, height: "auto" }}
         />
       </Box>
-    </Box>
+    </ContentPanel>
   )
 
   const ExploreSimple = () => (
-    <Box
-      id="explore-simple"
-      sx={{
-        display: "flex",
-        alignItems: { sm: "flex-start", lg: "center" },
-        flexDirection: { sm: "column", lg: "row" },
-        gap: (theme) => theme.layout.spacing.md,
-        color: (theme) => theme.palette.blue.darkest,
-        width: "100%",
-      }}
+    <ContentPanel
+      id="explore"
     >
       {/* Image column */}
       <Box
@@ -128,41 +146,10 @@ export default function ContentPanels() {
           </Typography>
         </LeadingMarkerText>
       </Box>
-    </Box>
+    </ContentPanel>
   )
 
-  const EmpowerSimple = () => (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        gap: (theme) => theme.layout.spacing.md,
-        color: (theme) => theme.palette.blue.darkest,
-        width: "100%",
-        paddingTop: { xs: 3, md: 14 },
-      }}
-    >
-      <LeadingMarkerText title="Empower">
-        <Typography variant="body1">
-          your community with data that helps you understand the impacts of
-          operational decisions
-        </Typography>
-      </LeadingMarkerText>
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "center",
-          mt: (theme) => theme.layout.spacing.sm,
-        }}
-      >
-        <CircularArrowButton
-          onClick={scrollToNextSection}
-          ariaLabel="open-empower"
-        />
-      </Box>
-    </Box>
-  )
+
   // Get background color for each panel
   const getPanelBgColor = (panelType: PanelType, theme: Theme) => {
     switch (panelType) {
@@ -504,7 +491,7 @@ export default function ContentPanels() {
         />
 
         <Spacer height={{ xs: 100, lg: 0 }} />
-        {/* Panel Component - Explore detail */}
+        {/* Explore panel */}
         <PanelWithDetail
           panelType="explore"
           isActive={activePanel === "explore"}
@@ -897,7 +884,26 @@ export default function ContentPanels() {
         <Spacer height={{ xs: 100, lg: 0 }} />
         {/* Empower panel */}
         <Box sx={{ py: 4 }}>
-          <EmpowerSimple />
+          <ContentPanel id="empower" smallScreenAlign="center" largeScreenFlexDir="column">
+            <LeadingMarkerText title="Empower">
+              <Typography variant="body1">
+                your community with data that helps you understand the impacts of
+                operational decisions
+              </Typography>
+            </LeadingMarkerText>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "center",
+                mt: (theme) => theme.layout.spacing.sm,
+              }}
+            >
+              <CircularArrowButton
+                onClick={scrollToNextSection}
+                ariaLabel="open-empower"
+              />
+            </Box>
+          </ContentPanel>
         </Box>
       </Box>
     </BasePanel>

--- a/apps/main/app/sections/ContentPanels.tsx
+++ b/apps/main/app/sections/ContentPanels.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react"
 import { Box, Typography, Grid, IconButton, useTheme } from "@repo/ui/mui"
 import type { Theme } from "@mui/material/styles"
+import { ResponsiveStyleValue } from "@mui/system"
 import {
   BasePanel,
   LeadingMarkerText,
@@ -59,9 +60,11 @@ export default function ContentPanels() {
 
   const LearnSimple = () => (
     <Box
+      id="learn-simple"
       sx={{
         display: "flex",
-        alignItems: "center",
+        alignItems: { sm: "flex-start", lg: "center" },
+        flexDirection: { sm: "column-reverse", lg: "row" },
         gap: (theme) => theme.layout.spacing.md,
         color: (theme) => theme.palette.blue.darkest,
         width: "100%",
@@ -96,9 +99,11 @@ export default function ContentPanels() {
 
   const ExploreSimple = () => (
     <Box
+      id="explore-simple"
       sx={{
         display: "flex",
-        alignItems: "center",
+        alignItems: { sm: "flex-start", lg: "center" },
+        flexDirection: { sm: "column", lg: "row" },
         gap: (theme) => theme.layout.spacing.md,
         color: (theme) => theme.palette.blue.darkest,
         width: "100%",
@@ -498,6 +503,7 @@ export default function ContentPanels() {
           }
         />
 
+        <Spacer height={{ xs: 100, lg: 0 }} />
         {/* Panel Component - Explore detail */}
         <PanelWithDetail
           panelType="explore"
@@ -888,7 +894,7 @@ export default function ContentPanels() {
             </>
           }
         />
-
+        <Spacer height={{ xs: 100, lg: 0 }} />
         {/* Empower panel */}
         <Box sx={{ py: 4 }}>
           <EmpowerSimple />

--- a/apps/main/app/sections/IntroSection.tsx
+++ b/apps/main/app/sections/IntroSection.tsx
@@ -25,16 +25,18 @@ const IntroSection = () => {
         includeHeaderSpacing={true}
         contentColumn="left"
         contentAlignment={{
-          justifyContent: "center",
-          alignItems: "center",
+          justifyContent: { xs: "flex-end", md: "flex-end", lg: "center" },
+          alignItems: "flex-start",
         }}
         sx={{
           position: "relative",
+
         }}
         leftContent={
           <Box
             sx={{
-              width: (theme) => theme.layout.textContainer.maxWidth,
+              width: '100%',
+              maxWidth: (theme) => theme.layout.textContainer.maxWidth, // This is setting 
               textAlign: "left",
               zIndex: theme.zIndex.introText,
             }}
@@ -111,6 +113,9 @@ const IntroSection = () => {
             bottom: { xs: 0, md: "26%" },
             zIndex: theme.zIndex.introForegroundImages,
             pointerEvents: "none",
+            transform: { xs: "scale(0.8)", md: "scale(1.20)", lg: "scale(1)" },
+            transformOrigin: "top right",
+            willChange: "transform",
           }}
         >
           <FloatingImageMarkers

--- a/packages/ui/src/components/panels/TwoColumnPanel.tsx
+++ b/packages/ui/src/components/panels/TwoColumnPanel.tsx
@@ -3,6 +3,7 @@
 import React from "react"
 import { Box, Typography, BoxProps } from "@mui/material"
 import { styled } from "@mui/material/styles"
+import { ResponsiveStyleValue } from "@mui/system"
 
 interface TwoColumnPanelProps extends BoxProps {
   /** Content for left column */
@@ -25,8 +26,8 @@ interface TwoColumnPanelProps extends BoxProps {
   contentColumn?: "left" | "right"
   /** Flex alignment for the content column */
   contentAlignment?: {
-    justifyContent?: "flex-start" | "center" | "flex-end"
-    alignItems?: "flex-start" | "center" | "flex-end" | "stretch"
+    justifyContent?: ResponsiveStyleValue<"flex-start" | "center" | "flex-end">
+    alignItems?: ResponsiveStyleValue<"flex-start" | "center" | "flex-end" | "stretch">
   }
   /** Text color - theme color path or hex color */
   textColor?: string
@@ -62,9 +63,12 @@ const TwoColumnRoot = styled(Box, {
     boxSizing: "border-box",
     display: "flex",
     flexDirection: "row",
-    
+
     // Header spacing via padding-top
     paddingTop: includeHeaderSpacing ? `${theme.layout.headerHeight}px` : 0,
+
+    paddingLeft: '78px',
+    paddingRight: '78px',
 
     // Background color
     backgroundColor: backgroundColor || "transparent",
@@ -99,7 +103,7 @@ export function TwoColumnPanel({
   ...rest
 }: TwoColumnPanelProps) {
   const isLeftContent = contentColumn === "left"
-  
+
   return (
     <TwoColumnRoot
       fullHeight={fullHeight}

--- a/packages/ui/src/themes/theme.tsx
+++ b/packages/ui/src/themes/theme.tsx
@@ -593,7 +593,7 @@ const theme = createTheme({
   },
   // Custom breakpoints
   breakpoints: {
-    values: { xs: 0, sm: 600, md: 820, lg: 1200, xl: 1536 },
+    values: { xs: 0, sm: 600, md: 900, lg: 1200, xl: 1536 },
   },
   // Card typography scale
   cards: {


### PR DESCRIPTION
This pull request adds responsive features (on tablet) to the intro section as well as the content panels, which have now been cleaned up into one component `ContentPanel.`
 
On tablets, the orientation of the content panels now becomes vertical, so we'll have to address what happens on bigger tablets like the iPad pro, where the arrow button goes all the way to the right and looks strange. But since we were planning on replacing that button anyway, I decided to leave it as is for now. 

For the intro section, on tablets, the title is displayed at the bottom left of the screen, with the bubbles scaled to fit in the upper right. 

I've also updated the theme breakpoints to the MUI defaults. I left the code in case we want to change it. 