### PR TITLE
fix/responsiveness + height adjustment necessary for animation

### DIFF
--- a/apps/main/app/sections/ContentPanels.tsx
+++ b/apps/main/app/sections/ContentPanels.tsx
@@ -92,9 +92,13 @@ export default function ContentPanels() {
   }
 
   const LearnSimple = () => (
-    <ContentPanel
-      id="learn"
-      smallScreenFlexDir="column-reverse"
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: { sm: "flex-start", lg: "center" },
+        flexDirection: { sm: "column-reverse", lg: "row" },
+        gap: (theme) => theme.layout.spacing.md,
+      }}
     >
       {/* Text column */}
       <Box sx={{ flex: 1, minWidth: 0 }}>
@@ -120,12 +124,17 @@ export default function ContentPanels() {
           sx={{ width: "100%", maxWidth: 520, height: "auto" }}
         />
       </Box>
-    </ContentPanel>
+    </Box>
   )
 
   const ExploreSimple = () => (
-    <ContentPanel
-      id="explore"
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: { sm: "flex-start", lg: "center" },
+        flexDirection: { sm: "column", lg: "row" },
+        gap: (theme) => theme.layout.spacing.md,
+      }}
     >
       {/* Image column */}
       <Box
@@ -146,7 +155,7 @@ export default function ContentPanels() {
           </Typography>
         </LeadingMarkerText>
       </Box>
-    </ContentPanel>
+    </Box>
   )
 
 


### PR DESCRIPTION
The ContentPanel wrapper component causes layout shift when users click the "Explore" panel. The Explore panel "jumps" during the slide animation instead of smoothly transitioning possibly because the ContentPanel wrapper introduces an additional layout layer between the animation container and the content. This would cause the height measurement system to calculate space based on the wrapped layout, but the animation renders with a different layout structure, causing a mismatch that results in layout shift.

The animation relies on pre-calculating the detail panel's height:

```
   const measureHeight = () => {
     if (detailPanelRef.current) {
       const height = detailPanelRef.current.scrollHeight // Measures height
       setContainerHeight(height) // Allocates space before animation
     }
   }
```

Solution: Apply responsive properties directly to the inner Box components instead of using a wrapper:
 
Before:
```
<ContentPanel smallScreenFlexDir="column-reverse" largeScreenFlexDir="row">
  <Box>Content that gets animated</Box>
</ContentPanel>
```

After:
```
<Box sx={{
  flexDirection: { xs: "column-reverse", lg: "row" },
  alignItems: { xs: "flex-start", lg: "center" },
  // No wrapper layer to interfere with height measurement
}}>
  Content that gets animated
</Box>
```

This is the only place in the main app codebase that uses these height-based animations.
