### PR TITLE
fix/timing issue: style is not done loading error

### DIFF
--- a/packages/map/src/context/MapContext.tsx
+++ b/packages/map/src/context/MapContext.tsx
@@ -223,6 +223,22 @@ export function MapProvider({ children }: { children: ReactNode }) {
     addSource: (id, source) => {
       const map = mapRef.current?.getMap()
       if (!map || map.getSource(id)) return
+      
+      // If style isn't loaded, wait for it to load then retry
+      if (!map.isStyleLoaded()) {
+        const retryAddSource = () => {
+          try {
+            if (map.getSource(id)) return // Already added
+            map.addSource(id, source)
+          } catch (err) {
+            console.error(`Failed to add source '${id}' on retry:`, err)
+          }
+        }
+        
+        map.once('styledata', retryAddSource)
+        return
+      }
+      
       try {
         map.addSource(id, source)
       } catch (err) {
@@ -253,6 +269,37 @@ export function MapProvider({ children }: { children: ReactNode }) {
     ) => {
       const map = mapRef.current?.getMap()
       if (!map || map.getLayer(id) || !map.getSource(source)) return
+      
+      // If style isn't loaded, wait for it to load then retry
+      if (!map.isStyleLoaded()) {
+        const retryAddLayer = () => {
+          try {
+            if (map.getLayer(id) || !map.getSource(source)) return // Already added or source missing
+            
+            const { beforeId, ...otherProps } = others || {}
+            const layer = {
+              id,
+              source,
+              type,
+              ...(paint ? { paint } : {}),
+              ...(layout ? { layout } : {}),
+              ...otherProps,
+            } as LayerSpecification
+            
+            if (beforeId) {
+              map.addLayer(layer, beforeId)
+            } else {
+              map.addLayer(layer)
+            }
+          } catch (err) {
+            console.error(`Failed to add layer '${id}' on retry:`, err)
+          }
+        }
+        
+        map.once('styledata', retryAddLayer)
+        return
+      }
+      
       try {
         const { beforeId, ...otherProps } = others || {}
         const layer = {

--- a/packages/map/src/context/MapContext.tsx
+++ b/packages/map/src/context/MapContext.tsx
@@ -65,6 +65,19 @@ export function MapProvider({ children }: { children: ReactNode }) {
     CSSProperties | undefined
   >(undefined)
 
+  // Helper function to ensure operations happen after style loads
+  const withStyleLoaded = (operation: () => void) => {
+    const map = mapRef.current?.getMap()
+    if (!map) return
+    
+    if (!map.isStyleLoaded()) {
+      map.once('styledata', operation)
+      return
+    }
+    
+    operation()
+  }
+
   const contextValue: MapOperationsAPI = {
     mapRef,
     markers,
@@ -224,26 +237,14 @@ export function MapProvider({ children }: { children: ReactNode }) {
       const map = mapRef.current?.getMap()
       if (!map || map.getSource(id)) return
       
-      // If style isn't loaded, wait for it to load then retry
-      if (!map.isStyleLoaded()) {
-        const retryAddSource = () => {
-          try {
-            if (map.getSource(id)) return // Already added
-            map.addSource(id, source)
-          } catch (err) {
-            console.error(`Failed to add source '${id}' on retry:`, err)
-          }
+      withStyleLoaded(() => {
+        try {
+          if (map.getSource(id)) return // Already added
+          map.addSource(id, source)
+        } catch (err) {
+          console.error(`Failed to add source '${id}':`, err)
         }
-        
-        map.once('styledata', retryAddSource)
-        return
-      }
-      
-      try {
-        map.addSource(id, source)
-      } catch (err) {
-        console.error(`Failed to add source '${id}':`, err)
-      }
+      })
     },
 
     removeSource: (id) => {
@@ -270,56 +271,30 @@ export function MapProvider({ children }: { children: ReactNode }) {
       const map = mapRef.current?.getMap()
       if (!map || map.getLayer(id) || !map.getSource(source)) return
       
-      // If style isn't loaded, wait for it to load then retry
-      if (!map.isStyleLoaded()) {
-        const retryAddLayer = () => {
-          try {
-            if (map.getLayer(id) || !map.getSource(source)) return // Already added or source missing
-            
-            const { beforeId, ...otherProps } = others || {}
-            const layer = {
-              id,
-              source,
-              type,
-              ...(paint ? { paint } : {}),
-              ...(layout ? { layout } : {}),
-              ...otherProps,
-            } as LayerSpecification
-            
-            if (beforeId) {
-              map.addLayer(layer, beforeId)
-            } else {
-              map.addLayer(layer)
-            }
-          } catch (err) {
-            console.error(`Failed to add layer '${id}' on retry:`, err)
-          }
-        }
-        
-        map.once('styledata', retryAddLayer)
-        return
-      }
-      
-      try {
-        const { beforeId, ...otherProps } = others || {}
-        const layer = {
-          id,
-          source,
-          type,
-          ...(paint ? { paint } : {}),
-          ...(layout ? { layout } : {}),
-          ...otherProps,
-        } as LayerSpecification
+      withStyleLoaded(() => {
+        try {
+          if (map.getLayer(id) || !map.getSource(source)) return // Already added or source missing
+          
+          const { beforeId, ...otherProps } = others || {}
+          const layer = {
+            id,
+            source,
+            type,
+            ...(paint ? { paint } : {}),
+            ...(layout ? { layout } : {}),
+            ...otherProps,
+          } as LayerSpecification
 
-        // Use beforeId if provided, otherwise add to top
-        if (beforeId && typeof beforeId === "string") {
-          map.addLayer(layer, beforeId)
-        } else {
-          map.addLayer(layer)
+          // Use beforeId if provided, otherwise add to top
+          if (beforeId && typeof beforeId === "string") {
+            map.addLayer(layer, beforeId)
+          } else {
+            map.addLayer(layer)
+          }
+        } catch (err) {
+          console.error(`Failed to add layer '${id}':`, err)
         }
-      } catch (err) {
-        console.error(`Failed to add layer '${id}':`, err)
-      }
+      })
     },
 
     removeLayer: (id) => {


### PR DESCRIPTION
## Fix: Map "Style is not done loading" error

### Problem
Components using `useMapSources` and `useMapLayers` were throwing console errors when trying to add map sources and layers before the Mapbox style finished loading.

### Solution
Added proper style loading checks with automatic retry logic.

### Changes
- `addSource()` now waits for style load, then retries
- `addLayer()` now waits for style load, then retries  
- Proper TypeScript casting for layer specifications

### Outcome
- Patch for now
- Todo: Consider refactoring to expose style loading state at the hook level for cleaner dependency management. This would move the timing logic from MapContext to the hooks themselves, making the dependency on style loading more explicit and React-friendly.

```js
// Current (hidden dependency):
useMapSources(sources, [showMapView]) // Style loading dependency is hidden

// Todo (explicit dependency):
const { isStyleLoaded } = useMap()
useMapSources(sources, [showMapView, isStyleLoaded]) // Clear when it runs
```