### PR TITLE
add header overlay variant

### DIFF
--- a/apps/main/app/components/Header.tsx
+++ b/apps/main/app/components/Header.tsx
@@ -36,6 +36,9 @@ export function Header() {
       onDataClick={handleDataClick}
       onToolsClick={handleToolsClick}
       onAboutClick={handleAboutClick}
+      variant="overlay"
+      hideOnScroll={false}
+      showLanguageSwitcher={false}
     />
   )
 }

--- a/packages/ui/src/components/navigation/AppHeader.tsx
+++ b/packages/ui/src/components/navigation/AppHeader.tsx
@@ -16,6 +16,7 @@ export interface AppHeaderProps {
   onAboutClick?: () => void
 
   // Layout props
+  variant?: "fixed" | "overlay" | "static" | "sticky"
   hideOnScroll?: boolean
   showLanguageSwitcher?: boolean
 }
@@ -32,35 +33,11 @@ export function AppHeader({
   onDataClick,
   onToolsClick,
   onAboutClick,
+  variant = "fixed",
   hideOnScroll = true,
   showLanguageSwitcher = true,
 }: AppHeaderProps) {
   const theme = useTheme()
-
-  // Default handlers that just log - applications should provide their own
-  const handleDataClick = () => {
-    if (onDataClick) {
-      onDataClick()
-    } else {
-      console.log("Data click - no handler provided")
-    }
-  }
-
-  const handleToolsClick = (tool: "scenario-explorer" | "needs-search") => {
-    if (onToolsClick) {
-      onToolsClick(tool)
-    } else {
-      console.log(`Tools click: ${tool} - no handler provided`)
-    }
-  }
-
-  const handleAboutClick = () => {
-    if (onAboutClick) {
-      onAboutClick()
-    } else {
-      console.log("About click - no handler provided")
-    }
-  }
 
   return (
     <BaseHeader
@@ -68,14 +45,15 @@ export function AppHeader({
       onSectionClick={onSectionClick}
       showSecondaryNav={showSecondaryNav}
       secondaryNavItems={secondaryNavItems}
-      onDataClick={handleDataClick}
-      onToolsClick={handleToolsClick}
-      onAboutClick={handleAboutClick}
+      onDataClick={onDataClick}
+      onToolsClick={onToolsClick}
+      onAboutClick={onAboutClick}
       backgroundColor={theme.palette.overlay.water}
       textColor={theme.palette.text.primary}
       zIndex={theme.zIndex.appBar}
       borderRadius={theme.borderRadius.none}
       boxShadow="none"
+      variant={variant}
       hideOnScroll={hideOnScroll}
       showLanguageSwitcher={showLanguageSwitcher}
     />

--- a/packages/ui/src/components/navigation/BaseHeader.tsx
+++ b/packages/ui/src/components/navigation/BaseHeader.tsx
@@ -59,6 +59,7 @@ export interface BaseHeaderProps {
   boxShadow?: string
 
   // Layout props
+  variant?: "fixed" | "overlay" | "static" | "sticky"
   hideOnScroll?: boolean
   showLanguageSwitcher?: boolean
 }
@@ -68,7 +69,7 @@ const translations: TranslationsMap = {
     title: "COEQWAL",
     buttons: {
       tools: "Tools",
-      getData: "Download data",
+      getData: "Get data",
       about: "About COEQWAL",
     },
     tools: {
@@ -110,6 +111,7 @@ export function BaseHeader({
   zIndex = 1100,
   borderRadius = 0,
   boxShadow = "none",
+  variant = "fixed",
   hideOnScroll = true,
   showLanguageSwitcher = true,
 }: BaseHeaderProps) {
@@ -117,15 +119,17 @@ export function BaseHeader({
   const isMobile = useMediaQuery("(max-width:600px)")
   const isTablet = useMediaQuery("(max-width:900px)")
 
-  const buttonVariant = isMobile ? "text" : "standard"
   const buttonStyle = {
-    lineHeight: 1.1,
-    height: 36,
-    minHeight: 36,
-    letterSpacing: "0.75px",
-    fontSize: "0.95rem",
+    fontSize: "1.125rem",
     fontWeight: 500,
     color: textColor,
+    textTransform: "none" as const,
+    padding: "8px 16px",
+    transition: "opacity 0.2s ease",
+    "&:hover": {
+      backgroundColor: "transparent",
+      opacity: 0.7,
+    },
   }
 
   const { locale, isLoading } = useTranslation()
@@ -150,6 +154,15 @@ export function BaseHeader({
   const componentText =
     translations[safeLocale as keyof TranslationsMap] || translations.en
 
+  // Map variant to CSS position
+  const positionMap = {
+    fixed: "fixed" as const,
+    overlay: "absolute" as const,
+    static: "static" as const,
+    sticky: "sticky" as const,
+  }
+  const position = positionMap[variant]
+
   // Only show secondary navigation if explicitly enabled and not on mobile
   const displaySecondaryNav =
     showSecondaryNav && !isMobile && secondaryNavItems.length > 0
@@ -168,13 +181,15 @@ export function BaseHeader({
         },
       }}
       transition={{ duration: 0.3 }}
-      position="fixed"
+      position={position}
       sx={{
         zIndex,
         backgroundColor,
         color: textColor,
         borderRadius,
         boxShadow,
+        ...(position === "sticky" && { top: 0 }),
+        ...(position === "absolute" && { top: 0, left: 0, right: 0 }),
       }}
       elevation={0}
     >
@@ -279,82 +294,20 @@ export function BaseHeader({
                   onClick: () => onToolsClick("needs-search"),
                 },
               ]}
-              variant={buttonVariant}
+              variant="text"
               sx={buttonStyle}
             />
           )}
 
           {/* Data button */}
           {onDataClick && (
-            <Button
-              variant={buttonVariant}
-              onClick={onDataClick}
-              sx={{
-                ...buttonStyle,
-                color: textColor,
-                position: "relative",
-                overflow: "hidden",
-                transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
-                "&:hover": {
-                  backgroundColor: "rgba(255, 255, 255, 0.1)",
-                  "&::before": {
-                    opacity: 1,
-                  },
-                },
-                "&::before": {
-                  content: '""',
-                  position: "absolute",
-                  top: 0,
-                  left: "-100%",
-                  width: "100%",
-                  height: "100%",
-                  background:
-                    "linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent)",
-                  transition: "left 0.5s ease",
-                  opacity: 0,
-                },
-                "&:hover::before": {
-                  left: "100%",
-                },
-              }}
-            >
+            <Button variant="text" onClick={onDataClick} sx={buttonStyle}>
               {componentText.buttons.getData}
             </Button>
           )}
 
           {/* About button */}
-          <Button
-            variant={buttonVariant}
-            onClick={onAboutClick}
-            sx={{
-              ...buttonStyle,
-              color: textColor,
-              position: "relative",
-              overflow: "hidden",
-              transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
-              "&:hover": {
-                backgroundColor: "rgba(255, 255, 255, 0.1)",
-                "&::before": {
-                  opacity: 1,
-                },
-              },
-              "&::before": {
-                content: '""',
-                position: "absolute",
-                top: 0,
-                left: "-100%",
-                width: "100%",
-                height: "100%",
-                background:
-                  "linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent)",
-                transition: "left 0.5s ease",
-                opacity: 0,
-              },
-              "&:hover::before": {
-                left: "100%",
-              },
-            }}
-          >
+          <Button variant="text" onClick={onAboutClick} sx={buttonStyle}>
             {componentText.buttons.about}
           </Button>
 

--- a/packages/ui/src/components/navigation/NavDropdown.tsx
+++ b/packages/ui/src/components/navigation/NavDropdown.tsx
@@ -45,7 +45,6 @@ export function NavDropdown({
     lineHeight: 1.1,
     height: theme.spacing(4.5), // 36px to match other header buttons
     minHeight: theme.spacing(4.5),
-    letterSpacing: "0.75px",
     fontSize: "0.95rem",
     fontWeight: 500,
     color: theme.palette.text.primary,

--- a/packages/ui/src/themes/theme.tsx
+++ b/packages/ui/src/themes/theme.tsx
@@ -411,7 +411,6 @@ const cardTypographyMixins = {
   eyebrow: {
     color: "blue.medium",
     textTransform: "uppercase",
-    letterSpacing: "0.75px",
     fontSize: typeScale.compact.caption, // 0.75rem - compact captions/labels
     fontWeight: 500,
     display: "block",
@@ -1150,7 +1149,6 @@ const theme = createTheme({
         root: ({ theme }) => ({
           borderRadius: theme.borderRadius.pill,
           padding: "1px 15px", // to account for border width
-          letterSpacing: "0.75px",
           fontSize: "0.95rem",
           fontWeight: 500,
           backgroundColor: "transparent",


### PR DESCRIPTION
- Added variant prop to control header behavior: `variant?: "fixed" | "overlay" | "static" | "sticky"`
- Currently using `overlay`, i.e. header overlaps home panel, scrolls with page
- Cleaned up extra buttons, button style
- Changed link names, per Ted