### PR TITLE
Learn map tweaks

### DIFF
--- a/apps/main/app/components/map/hooks/useOutcomeMapLayer.ts
+++ b/apps/main/app/components/map/hooks/useOutcomeMapLayer.ts
@@ -37,7 +37,7 @@ const DEMAND_UNITS_OUTLINE_ID = "demand-units-outline"
 const BASEMAP_DIM_LAYER_ID = "basemap-dim-overlay"
 
 // Dimming overlay opacity (0 = no dim, 1 = full black)
-const BASEMAP_DIM_OPACITY = 0.35
+const BASEMAP_DIM_OPACITY = 0.15
 
 // API base URL
 const API_BASE = "https://api.coeqwal.org/api"
@@ -71,30 +71,6 @@ interface OutcomeLayerConfig {
   /** API short code for tier data */
   tierCode: string
 }
-
-/**
- * Preset bounds for each outcome type
- * These ensure consistent zooming when switching between outcomes
- * Format: [[minLng, minLat], [maxLng, maxLat]]
- */
-const OUTCOME_BOUNDS: Record<string, [[number, number], [number, number]]> = {
-  // CWS covers urban areas throughout Central Valley
-  "Community deliveries": [
-    [-122.5, 35.5],
-    [-119.0, 40.5],
-  ],
-  // AG_REV covers agricultural districts throughout Central Valley
-  "Agricultural revenue": [
-    [-122.5, 35.0],
-    [-118.5, 40.5],
-  ],
-}
-
-// Default bounds for Central Valley if no preset is defined
-const DEFAULT_BOUNDS: [[number, number], [number, number]] = [
-  [-122.5, 35.0],
-  [-118.5, 40.5],
-]
 
 /**
  * Configuration for each outcome type
@@ -510,25 +486,21 @@ export function useOutcomeMapLayer({
           }
         })
 
-        // Zoom to preset bounds for this outcome
         // This is a SEPARATE withMap call to ensure zoom happens even if styling encounters issues
         // and to always trigger when switching outcomes (regardless of previous map state)
         if (!cancelled) {
           mapAPI.withMap((mapRef) => {
             const map = mapRef.getMap()
-            const bounds = outcome
-              ? OUTCOME_BOUNDS[outcome] || DEFAULT_BOUNDS
-              : DEFAULT_BOUNDS
+            const currentCenter = map.getCenter()
+
+            const targetZoom = 6.5
 
             console.log(
-              `[useOutcomeMapLayer] Zooming to bounds for "${outcome}":`,
-              bounds,
+              `[useOutcomeMapLayer] Zooming to level ${targetZoom} for "${outcome}" (keeping current center)`,
             )
-
-            // Always use fitBounds to reset view, even if user has panned/zoomed manually
-            map.fitBounds(bounds, {
-              padding: { top: 300, bottom: 50, left: 100, right: 350 }, // Extra top padding to avoid tab coverage
-              maxZoom: 8,
+            map.easeTo({
+              zoom: targetZoom,
+              center: currentCenter, // Keep current center
               duration: 1000,
             })
           })

--- a/apps/main/app/components/map/overlays/MapOverlayPanels.tsx
+++ b/apps/main/app/components/map/overlays/MapOverlayPanels.tsx
@@ -34,7 +34,7 @@ import {
   useIsOutcomeVisualizationActive,
   type SectionId,
 } from "../store"
-import { useTransform, motion, useMotionValue } from "@repo/motion"
+import { useTransform, motion, useMotionValue, useMotionValueEvent } from "@repo/motion"
 import { useLearnScrollama, SCROLLAMA_CONFIG } from "../hooks/useLearnScrollama"
 
 export default function MapOverlayPanels() {
@@ -184,20 +184,43 @@ export default function MapOverlayPanels() {
     [0, 1],
   )
 
+  // TODO: find another way to allow map panning and disable triggering hidden interactive panel features.
   // Panel pointer events - derived from opacity to prevent invisible panels from receiving events
-  // When opacity < 0.5, pointer events are disabled entirely (including children)
+  // When opacity < 0.1, pointer events are disabled (prevents clicking hidden panels)
+  // Using lower threshold to ensure panels are truly invisible before allowing map panning
+  // Applied to inner motion.div so map panning still works through backgrounds
   const strategyInfoPointerEvents = useTransform(strategyInfoPanelOpacity, (v) =>
-    v < 0.5 ? "none" : "auto",
+    v < 0.1 ? "none" : "auto",
   )
   const keyOperationsPointerEvents = useTransform(keyOperationsPanelOpacity, (v) =>
-    v < 0.5 ? "none" : "auto",
+    v < 0.1 ? "none" : "auto",
   )
   const keyOutcomesPointerEvents = useTransform(keyOutcomesPanelOpacity, (v) =>
-    v < 0.5 ? "none" : "auto",
+    v < 0.1 ? "none" : "auto",
   )
   const summaryPointerEvents = useTransform(summaryPanelOpacity, (v) =>
-    v < 0.5 ? "none" : "auto",
+    v < 0.1 ? "none" : "auto",
   )
+
+  // Convert motion values to state to override panel's hardcoded pointerEvents: "auto"
+  const [strategyInfoPE, setStrategyInfoPE] = useState<"none" | "auto">("none")
+  const [keyOperationsPE, setKeyOperationsPE] = useState<"none" | "auto">("none")
+  const [keyOutcomesPE, setKeyOutcomesPE] = useState<"none" | "auto">("none")
+  const [summaryPE, setSummaryPE] = useState<"none" | "auto">("none")
+
+  // Sync motion values to state for use in MUI sx prop
+  useMotionValueEvent(strategyInfoPointerEvents, "change", (latest) => {
+    setStrategyInfoPE(latest as "none" | "auto")
+  })
+  useMotionValueEvent(keyOperationsPointerEvents, "change", (latest) => {
+    setKeyOperationsPE(latest as "none" | "auto")
+  })
+  useMotionValueEvent(keyOutcomesPointerEvents, "change", (latest) => {
+    setKeyOutcomesPE(latest as "none" | "auto")
+  })
+  useMotionValueEvent(summaryPointerEvents, "change", (latest) => {
+    setSummaryPE(latest as "none" | "auto")
+  })
 
   // Tooltip opacity - fade in and out (adjusted for compressed timing)
   const strategyInfoTooltipOpacity = useTransform(
@@ -725,7 +748,7 @@ export default function MapOverlayPanels() {
                 <motion.div
                   style={{
                     opacity: strategyInfoPanelOpacity,
-                    pointerEvents: strategyInfoPointerEvents,
+                    pointerEvents: "none", // Allow map panning through panel backgrounds
                   }}
                 >
                   <Box
@@ -750,17 +773,25 @@ export default function MapOverlayPanels() {
                           position: "relative",
                           width: "100%",
                           maxWidth: { xs: "100%", sm: "360px", md: "420px", lg: "460px", xl: "500px" },
-                          pointerEvents: "none",
+                          pointerEvents: strategyInfoPE, // Block panel AND tooltip when hidden
                         }}
                       >
                         <motion.div
                           ref={strategyInfoRef}
-                          style={{ pointerEvents: strategyInfoPointerEvents }}
+                          style={{ 
+                            pointerEvents: strategyInfoPointerEvents, // "none" when hidden, "auto" when visible
+                          }}
                         >
-                          <StrategyInfoPanel
-                            strategyValue="current-ops"
-                            onTitleClick={() => setStrategyTooltipClosed(false)}
-                          />
+                          <Box
+                            sx={{
+                              pointerEvents: strategyInfoPE, // Override panel's hardcoded "auto"
+                            }}
+                          >
+                            <StrategyInfoPanel
+                              strategyValue="current-ops"
+                              onTitleClick={() => setStrategyTooltipClosed(false)}
+                            />
+                          </Box>
                         </motion.div>
 
                         <ScrollTooltip
@@ -816,7 +847,7 @@ export default function MapOverlayPanels() {
                 <motion.div
                   style={{
                     opacity: keyOperationsPanelOpacity,
-                    pointerEvents: keyOperationsPointerEvents,
+                    pointerEvents: "none", // Allow map panning through panel backgrounds
                   }}
                 >
                   <Box
@@ -841,17 +872,25 @@ export default function MapOverlayPanels() {
                           position: "relative",
                           width: "100%",
                           maxWidth: { xs: "100%", sm: "360px", md: "420px", lg: "460px", xl: "500px" },
-                          pointerEvents: "none",
+                          pointerEvents: keyOperationsPE, // Block panel AND tooltip when hidden
                         }}
                       >
                         <motion.div
                           ref={keyOperationsRef}
-                          style={{ pointerEvents: keyOperationsPointerEvents }}
+                          style={{ 
+                            pointerEvents: keyOperationsPointerEvents, // "none" when hidden, "auto" when visible
+                          }}
                         >
-                          <KeyOperationsPanel
-                            strategyValue="current-ops"
-                            onTitleClick={() => setKeyOpsTooltipClosed(false)}
-                          />
+                          <Box
+                            sx={{
+                              pointerEvents: keyOperationsPE, // Override panel's hardcoded "auto"
+                            }}
+                          >
+                            <KeyOperationsPanel
+                              strategyValue="current-ops"
+                              onTitleClick={() => setKeyOpsTooltipClosed(false)}
+                            />
+                          </Box>
                         </motion.div>
 
                         <ScrollTooltip
@@ -900,7 +939,7 @@ export default function MapOverlayPanels() {
                 <motion.div
                   style={{
                     opacity: keyOutcomesPanelOpacity,
-                    pointerEvents: keyOutcomesPointerEvents,
+                    pointerEvents: "none", // Allow map panning through panel backgrounds
                   }}
                 >
                   <Box
@@ -925,19 +964,27 @@ export default function MapOverlayPanels() {
                           position: "relative",
                           width: "100%",
                           maxWidth: { xs: "100%", sm: "360px", md: "420px", lg: "460px", xl: "500px" },
-                          pointerEvents: "none",
+                          pointerEvents: keyOutcomesPE, // Block panel AND tooltip when hidden
                         }}
                       >
                         <motion.div
                           ref={keyOutcomesRef}
-                          style={{ pointerEvents: keyOutcomesPointerEvents }}
+                          style={{ 
+                            pointerEvents: keyOutcomesPointerEvents, // "none" when hidden, "auto" when visible
+                          }}
                         >
-                          <KeyOutcomesPanel
-                            scenarioId="s0020"
-                            onTitleClick={() =>
-                              setKeyOutcomesTooltipClosed(false)
-                            }
-                          />
+                          <Box
+                            sx={{
+                              pointerEvents: keyOutcomesPE, // Override panel's hardcoded "auto"
+                            }}
+                          >
+                            <KeyOutcomesPanel
+                              scenarioId="s0020"
+                              onTitleClick={() =>
+                                setKeyOutcomesTooltipClosed(false)
+                              }
+                            />
+                          </Box>
                         </motion.div>
 
                         <ScrollTooltip
@@ -1005,7 +1052,7 @@ export default function MapOverlayPanels() {
                 <motion.div
                   style={{
                     opacity: summaryPanelOpacity,
-                    pointerEvents: summaryPointerEvents,
+                    pointerEvents: "none", // Allow map panning through panel backgrounds
                   }}
                 >
                   <Box
@@ -1033,10 +1080,16 @@ export default function MapOverlayPanels() {
                       >
                         <motion.div
                           style={{
-                            pointerEvents: summaryPointerEvents,
+                            pointerEvents: summaryPointerEvents, // "none" when hidden, "auto" when visible
                           }}
                         >
-                          <SummaryPanel strategy="current-ops" />
+                          <Box
+                            sx={{
+                              pointerEvents: summaryPE, // Override panel's hardcoded "auto"
+                            }}
+                          >
+                            <SummaryPanel strategy="current-ops" />
+                          </Box>
                         </motion.div>
                       </Box>
                     </Box>


### PR DESCRIPTION
This PR fixes some Learn Map panel interaction issues and enhances the outcome data map visualizations.

- adjusted pointer events in order to enable map panning without enabling activation of hidden panel interactions (but some are still sneaking through -- this needs more work later)
- better centered visualizations of outcome data on the map