### PR TITLE
fix/ remove next/navigation coupling from ui package

### DIFF
--- a/apps/main/app/components/Header.tsx
+++ b/apps/main/app/components/Header.tsx
@@ -9,6 +9,11 @@ import { AppHeader } from "@repo/ui"
 export function Header() {
   const router = useRouter()
 
+  // Handle logo click - refresh page without full reload
+  const handleLogoClick = () => {
+    router.refresh()
+  }
+
   // Handle data page navigation
   const handleDataClick = () => {
     router.push("/data")
@@ -33,6 +38,7 @@ export function Header() {
 
   return (
     <AppHeader
+      onLogoClick={handleLogoClick}
       onDataClick={handleDataClick}
       // onToolsClick={handleToolsClick} // Disabled temporarily
       onAboutClick={handleAboutClick}

--- a/packages/ui/src/components/navigation/AppHeader.tsx
+++ b/packages/ui/src/components/navigation/AppHeader.tsx
@@ -11,6 +11,7 @@ export interface AppHeaderProps {
   secondaryNavItems?: SecondaryNavItem[]
 
   // Action handlers
+  onLogoClick?: () => void
   onDataClick?: () => void
   onToolsClick?: (tool: "scenario-explorer" | "needs-search") => void
   onAboutClick?: () => void
@@ -30,6 +31,7 @@ export function AppHeader({
   onSectionClick,
   showSecondaryNav = false,
   secondaryNavItems = [],
+  onLogoClick,
   onDataClick,
   onToolsClick,
   onAboutClick,
@@ -45,6 +47,7 @@ export function AppHeader({
       onSectionClick={onSectionClick}
       showSecondaryNav={showSecondaryNav}
       secondaryNavItems={secondaryNavItems}
+      onLogoClick={onLogoClick}
       onDataClick={onDataClick}
       onToolsClick={onToolsClick}
       onAboutClick={onAboutClick}

--- a/packages/ui/src/components/navigation/BaseHeader.tsx
+++ b/packages/ui/src/components/navigation/BaseHeader.tsx
@@ -14,7 +14,6 @@ import {
   useTransform,
 } from "@repo/motion"
 import { useRef, useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
 
 const MotionAppBar = motion.create(AppBar)
 
@@ -56,6 +55,7 @@ export interface BaseHeaderProps {
   secondaryNavItems?: SecondaryNavItem[]
 
   // Action handlers
+  onLogoClick?: () => void
   onDataClick?: () => void
   onToolsClick?: (tool: "scenario-explorer" | "needs-search") => void
   onAboutClick?: () => void
@@ -113,6 +113,7 @@ export function BaseHeader({
   onSectionClick,
   showSecondaryNav = false,
   secondaryNavItems = [],
+  onLogoClick,
   onDataClick,
   onToolsClick,
   onAboutClick,
@@ -129,12 +130,6 @@ export function BaseHeader({
   // Responsive breakpoints (using standard MUI breakpoints)
   const isMobile = useMediaQuery("(max-width:600px)")
   const isTablet = useMediaQuery("(max-width:900px)")
-
-  const router = useRouter()
-
-  const handleLogoClick = () => {
-    router.refresh() // re-fetches server components/data without a full reload
-  }
 
   const buttonStyle = {
     fontSize: "1rem",
@@ -258,9 +253,9 @@ export function BaseHeader({
           style={{ minHeight: "var(--header-h)" }}
         >
           <Box
-            component={motion.button}
-            type="button"
-            onClick={handleLogoClick}
+            component={onLogoClick ? motion.button : motion.div}
+            type={onLogoClick ? "button" : undefined}
+            onClick={onLogoClick}
             style={{
               scale: logoScale,
               originX: 0,
@@ -272,17 +267,19 @@ export function BaseHeader({
               alignItems: "center",
               pl: 2,
               width: 168,
-              background: "transparent",
-              border: "none",
-              padding: 0,
-              cursor: "pointer",
-              "&:focus-visible": {
-                outline: "2px solid currentColor",
-                outlineOffset: "4px",
-                borderRadius: "6px",
-              },
+              ...(onLogoClick && {
+                background: "transparent",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+                "&:focus-visible": {
+                  outline: "2px solid currentColor",
+                  outlineOffset: "4px",
+                  borderRadius: "6px",
+                },
+              }),
             }}
-            aria-label="Refresh page"
+            aria-label={onLogoClick ? "Refresh page" : undefined}
           >
             <Logo />
           </Box>


### PR DESCRIPTION
`BaseHeader` was importing` useRouter` from `next/navigation`, but `@repo/ui` is a shared package that should be framework-agnostic.

Changes:
- Removed `next/navigation` import from `BaseHeader`
- Added `onLogoClick `callback prop instead
- App-layer` Header.tsx` now handles the `router.refresh()` logic