### PR TITLE
fix: remove next/navigation from UI package, fix logo scroll

### DIFF
--- a/apps/main/app/components/Header.tsx
+++ b/apps/main/app/components/Header.tsx
@@ -1,41 +1,62 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { AppHeader } from "@repo/ui"
+import { useTheme } from "@mui/material/styles"
+import { BaseHeader } from "@repo/ui"
 
 /**
- * Main application header with Next.js routing logic
+ * Main application header with Next.js routing and theme integration
+ * Uses BaseHeader directly (skipping AppHeader wrapper for simplicity)
  */
 export function Header() {
   const router = useRouter()
+  const theme = useTheme()
 
-  // Handle data page navigation
+  // Smooth scroll to top using requestAnimationFrame
+  // Native smooth scroll gets interrupted by React state changes during the tabs
+  // transition zone, so we use manual RAF animation which can't be interrupted
+  const handleLogoClick = () => {
+    const start = window.scrollY
+    if (start === 0) return // Already at top
+    
+    const startTime = performance.now()
+    const duration = 600 // ms
+    
+    const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3)
+    
+    const animateScroll = (currentTime: number) => {
+      const elapsed = currentTime - startTime
+      const progress = Math.min(elapsed / duration, 1)
+      const eased = easeOutCubic(progress)
+      
+      window.scrollTo(0, start * (1 - eased))
+      
+      if (progress < 1) {
+        requestAnimationFrame(animateScroll)
+      }
+    }
+    
+    requestAnimationFrame(animateScroll)
+  }
+
   const handleDataClick = () => {
     router.push("/data")
   }
 
-  // // Handle tools dropdown clicks
-  // const handleToolsClick = (tool: "scenario-explorer" | "needs-search") => {
-  //   if (tool === "scenario-explorer") {
-  //     // TODO: Navigate to scenario data explorer
-  //     console.log("Navigate to scenario data explorer")
-  //   } else if (tool === "needs-search") {
-  //     // TODO: Navigate to needs-based search
-  //     console.log("Navigate to needs-based search")
-  //   }
-  // }
-
-  // Handle about page clicks
   const handleAboutClick = () => {
-    // TODO: Navigate to about page once it exists
     console.log("Navigate to about page")
   }
 
   return (
-    <AppHeader
+    <BaseHeader
+      onLogoClick={handleLogoClick}
       onDataClick={handleDataClick}
-      // onToolsClick={handleToolsClick} // Disabled temporarily
       onAboutClick={handleAboutClick}
+      backgroundColor={theme.palette.utility.white}
+      textColor={theme.palette.text.primary}
+      zIndex={theme.zIndex.appBar}
+      borderRadius={theme.borderRadius.none}
+      boxShadow="none"
       hideOnScroll={false}
       showLanguageSwitcher={false}
     />

--- a/packages/ui/src/components/navigation/BaseHeader.tsx
+++ b/packages/ui/src/components/navigation/BaseHeader.tsx
@@ -14,7 +14,6 @@ import {
   useTransform,
 } from "@repo/motion"
 import { useRef, useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
 
 const MotionAppBar = motion.create(AppBar)
 
@@ -56,6 +55,7 @@ export interface BaseHeaderProps {
   secondaryNavItems?: SecondaryNavItem[]
 
   // Action handlers
+  onLogoClick?: () => void
   onDataClick?: () => void
   onToolsClick?: (tool: "scenario-explorer" | "needs-search") => void
   onAboutClick?: () => void
@@ -113,6 +113,7 @@ export function BaseHeader({
   onSectionClick,
   showSecondaryNav = false,
   secondaryNavItems = [],
+  onLogoClick,
   onDataClick,
   onToolsClick,
   onAboutClick,
@@ -129,12 +130,6 @@ export function BaseHeader({
   // Responsive breakpoints (using standard MUI breakpoints)
   const isMobile = useMediaQuery("(max-width:600px)")
   const isTablet = useMediaQuery("(max-width:900px)")
-
-  const router = useRouter()
-
-  const handleLogoClick = () => {
-    router.refresh() // re-fetches server components/data without a full reload
-  }
 
   const buttonStyle = {
     fontSize: "1rem",
@@ -260,7 +255,13 @@ export function BaseHeader({
           <Box
             component={motion.button}
             type="button"
-            onClick={handleLogoClick}
+            onClick={() => {
+              if (onLogoClick) {
+                onLogoClick()
+              } else {
+                window.scrollTo({ top: 0, behavior: "smooth" })
+              }
+            }}
             style={{
               scale: logoScale,
               originX: 0,
@@ -282,7 +283,7 @@ export function BaseHeader({
                 borderRadius: "6px",
               },
             }}
-            aria-label="Refresh page"
+            aria-label="Scroll to top"
           >
             <Logo />
           </Box>


### PR DESCRIPTION
## The build error
`BaseHeader` imported `next/navigation`, but `BaseHeader` is in the UI package, which is compiled separately without Next.js, causing build failures.

## The fix
1. Removed `next/navigation` from `BaseHeader` and added `onLogoClick` callback prop instead
2. App's `Header` implements scroll using `requestAnimationFrame` animation

Why RAF instead of `window.scrollTo({ behavior: "smooth" })`? 
Native smooth scroll gets interrupted by React state changes during tab transitions.
RAF animation runs independently and can't be interrupted.

## Files changed
- `packages/ui/.../BaseHeader.tsx` - Removed next/navigation, added onLogoClick prop
- `apps/main/.../Header.tsx` - Uses BaseHeader directly with RAF scroll animation