### PR TITLE
Test: markdown-only push must not deploy

### DIFF
--- a/apps/main/README.md
+++ b/apps/main/README.md
@@ -54,7 +54,7 @@ StrictMode
                 └── {children}                                 (page content)
 ```
 
-**Translation provider:** Wrapping `DataProvider`, `ThemeRegistry`, and all layout chrome as shown. Swap your new package in at that layer.
+**Translation provider:** Wrapping `DataProvider`, `ThemeRegistry`, and all layout chrome as shown. We can swap the new translation package in at that layer.
 
 `app/page.tsx` (Server Component) renders the home-only stack:
 


### PR DESCRIPTION
Verifies that .md-only changes inside an app folder do not trigger Deploy to Amplify