### PR TITLE
Test: lockfile-regen label opt-out

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,4 @@
+# regen test (this line was used on May 14 2026 to create a file change to test deployment workflow and can be deleted) )
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
Verifies that the lockfile-regen label suppresses broad-impact notify.