### PR TITLE
get-started/consolidate panels into shared InfoCardGrid layout

### DIFF
--- a/apps/main/app/features/scenarioExplorer/getStarted/GetStartedView.tsx
+++ b/apps/main/app/features/scenarioExplorer/getStarted/GetStartedView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react"
 import { Box, useTheme, alpha } from "@repo/ui/mui"
 import { useMapMode, useStoryboardMapInteractive } from "../../map/store"
 import TierAnimationSection from "../animation/TierAnimationSection"
+import PanelFrame from "./panels/PanelFrame"
 import {
   WelcomePanel,
   WaterIssuesPanel,
@@ -88,22 +89,13 @@ export default function GetStartedView() {
       {/* Map panel (TierAnimationSection): thin outer frame + rounded shell.
           Radius applied around (not inside) the pinned map overlay so the
           tier animation's own 100vh geometry is preserved. */}
-      <Box
-        sx={{
+      <PanelFrame
+        outerSx={{
           pointerEvents: storyboardMapInteractive ? "none" : "auto",
-          px: theme.layout.panel.insetX,
-          py: theme.layout.panel.insetY,
         }}
       >
-        <Box
-          sx={{
-            borderRadius: theme.layout.panel.radius,
-            overflow: "hidden",
-          }}
-        >
-          <TierAnimationSection />
-        </Box>
-      </Box>
+        <TierAnimationSection />
+      </PanelFrame>
 
       {/* Post-map dark wash: modal-style black backdrop (opacity from
           theme.background.modalBackdropOpacity) behind panels 6-9 that

--- a/apps/main/app/features/scenarioExplorer/getStarted/content.ts
+++ b/apps/main/app/features/scenarioExplorer/getStarted/content.ts
@@ -1,0 +1,232 @@
+/**
+ * getStarted/content
+ */
+
+import { type OutcomeCode } from "../../../content/outcomes"
+
+export interface WaterIssueTheme {
+  title: string
+  description: string
+  themeKey: string
+  dimmed?: boolean
+}
+
+export const WATER_ISSUE_THEMES: ReadonlyArray<WaterIssueTheme> = [
+  {
+    title: "Community water systems",
+    description:
+      "Whether people and communities can reliably access safe drinking water for daily life, health, and essential services",
+    themeKey: "cws",
+  },
+  {
+    title: "Farms and groundwater",
+    description:
+      "Whether agricultural water deliveries can sustain food production, while preventing over-draft of groundwater basins",
+    themeKey: "ag_gw",
+  },
+  {
+    title: "Rivers, salmon and the Delta ecosystem",
+    description:
+      "Whether rivers, salmon, and the Delta estuary receive the flows they need to thrive",
+    themeKey: "eco",
+  },
+  {
+    title: "The Delta as a living place",
+    description:
+      "Whether the Delta is a place where communities, farms, and ecosystems coexist and thrive",
+    themeKey: "delta",
+  },
+  {
+    title: "Operations and impacts",
+    description:
+      "How management decisions affect trade-offs, equity and resilience",
+    themeKey: "governance",
+    dimmed: true,
+  },
+] as const
+
+export interface HydroclimateFuture {
+  title: string
+  description: string
+  dimmed?: boolean
+}
+
+export const HYDROCLIMATES: ReadonlyArray<HydroclimateFuture> = [
+  {
+    title: "Historical hydroclimate (baseline)",
+    description:
+      "Temperature, precipitation, and streamflow patterns reflect historical conditions",
+  },
+  {
+    title: "Moderate-dry climate risk",
+    description:
+      "Warmer and slightly drier conditions (\u22121% runoff change) - 50th percentile level of concern",
+  },
+  {
+    title: "Moderate-wet climate risk",
+    description:
+      "Warmer and wetter conditions (+7% runoff change) - 44th percentile level of concern",
+    dimmed: true,
+  },
+  {
+    title: "High climate risk",
+    description:
+      "Warmer and much drier conditions (\u22127% runoff change) - 95th percentile level of concern",
+  },
+  {
+    title: "Extreme climate risk",
+    description:
+      "Much warmer and extremely drier conditions (\u221221% runoff change) - 99th percentile level of concern",
+    dimmed: true,
+  },
+] as const
+
+export interface KeyOutcome {
+  outcomeCode: OutcomeCode
+  title: string
+  description: string
+}
+
+export const KEY_OUTCOMES: ReadonlyArray<KeyOutcome> = [
+  {
+    outcomeCode: "CWS_DEL",
+    title: "Community water deliveries",
+    description:
+      "Reliability of water supplies to communities to satisfy essential drinking water needs",
+  },
+  {
+    outcomeCode: "AG_REV",
+    title: "Agricultural revenue",
+    description:
+      "Economic productivity of agricultural crops based on water availability",
+  },
+  {
+    outcomeCode: "ENV_FLOWS",
+    title: "Environmental flows",
+    description:
+      "Seasonal patterns of river flows needed to support healthy ecosystems",
+  },
+  {
+    outcomeCode: "DELTA_ECO",
+    title: "Delta estuary ecology",
+    description:
+      "Seasonal patterns of flows needed to support the health of the Bay Delta estuary",
+  },
+  {
+    outcomeCode: "WRC_SALMON_AB",
+    title: "Winter-run salmon",
+    description:
+      "Population status of Sacramento River winter-run Chinook salmon",
+  },
+  {
+    outcomeCode: "FW_DELTA_USES",
+    title: "Freshwater for in-Delta uses",
+    description:
+      "Availability of freshwater in the Delta to support local communities and farms",
+  },
+  {
+    outcomeCode: "FW_EXP",
+    title: "Freshwater for Delta exports",
+    description: "Availability of freshwater for export to other regions",
+  },
+  {
+    outcomeCode: "RES_STOR",
+    title: "Reservoir storage",
+    description: "Levels of water stored in major reservoirs",
+  },
+  {
+    outcomeCode: "GW_STOR",
+    title: "Groundwater storage",
+    description: "Amount and trends of water stored in groundwater basins",
+  },
+] as const
+
+export interface InterpretingLens {
+  label: string
+  description: string
+}
+
+export const INTERPRETING_LENSES: ReadonlyArray<InterpretingLens> = [
+  {
+    label: "Trade-offs",
+    description:
+      "How outcomes improve or decline together across scenarios",
+  },
+  {
+    label: "Equity",
+    description:
+      "How benefits and impacts are distributed across outcomes and locations of interest",
+  },
+  {
+    label: "Resilience",
+    description:
+      "How outcomes change under increasing levels of climate stress",
+  },
+] as const
+
+export interface VizTool {
+  title: string
+  description: string
+  dimmed?: boolean
+}
+
+export const VIZ_TOOLS: ReadonlyArray<VizTool> = [
+  {
+    title: "Map view",
+    description:
+      "Displays how outcomes vary across locations of interest and reveals spatial patterns in outcomes.",
+  },
+  {
+    title: "Distribution viewer",
+    description:
+      "Highlights how outcomes vary across key outcomes and among different locations of interest and communities, revealing who benefits and who is most impacted.",
+  },
+  {
+    title: "Radar chart",
+    description:
+      "Shows how outcomes vary within a scenario and enables comparisons across scenarios, highlighting commonalities, differences, and trade-offs.",
+  },
+  {
+    title: "Scatterplot",
+    description:
+      "Compares scenarios at the system level to reveal the relative effects of operational decisions and climate change on outcomes.",
+    dimmed: true,
+  },
+  {
+    title: "Heatmaps",
+    description:
+      "Show how scenarios perform across increasing levels of climate stress, highlighting which management strategies are most resilient or vulnerable to climate impacts.",
+  },
+] as const
+
+export interface ScenarioQuestion {
+  title: string
+  description: string
+}
+
+export const SCENARIO_QUESTIONS: ReadonlyArray<ScenarioQuestion> = [
+  {
+    title: "How is my water interest doing now?",
+    description:
+      "This is the current operations scenario under the historical hydroclimate, which serves as a baseline for comparison.",
+  },
+  {
+    title: "How could alternative strategies impact my water interest?",
+    description:
+      "Select one or more scenarios to compare against the current operations scenario under the historical hydroclimate.",
+  },
+  {
+    title: "How does climate change shift the picture?",
+    description:
+      "Select scenarios that represent how current operations and alternative strategies perform under alternative hydroclimates.",
+  },
+] as const
+
+export const CAVEATS: ReadonlyArray<string> = [
+  "All scenarios are created by CalSim3, a water planning tool to guide operations of California\u2019s water supply system in the Central Valley.",
+  "The scenarios do not include all regions of California nor certain aspects of our water system that may be of interest.",
+  "Key outcomes summarize scenario results over a 100-year period. Annual variation in outcomes can be explored with the DATA IN DEPTH view and in the GET DATA section.",
+  "The hydroclimates used in scenarios approximate the range of historical and potential future conditions that our system may experience. They do not represent historical observations or predicted future conditions according to climate models.",
+  "Estimates of water deliveries to locations of interest with small water demands may be less reliable than delivery estimates for water users that receive larger volumes.",
+  "The outcomes of CalSim scenarios are best interpreted in a comparative manner \u2014 evaluating how outcomes change relative to current operations (as a baseline) is more appropriate than assessing the specific outcomes of any particular scenario.",
+] as const

--- a/apps/main/app/features/scenarioExplorer/getStarted/panels/BeforeYouBeginPanel.tsx
+++ b/apps/main/app/features/scenarioExplorer/getStarted/panels/BeforeYouBeginPanel.tsx
@@ -4,15 +4,7 @@ import { Box, useTheme } from "@repo/ui/mui"
 import { LinedList, WaterDroplet } from "@repo/ui"
 import PanelShell from "./PanelShell"
 import PanelHeading from "./PanelHeading"
-
-const CAVEATS = [
-  "All scenarios are created by CalSim3, a water planning tool to guide operations of California\u2019s water supply system in the Central Valley.",
-  "The scenarios do not include all regions of California nor certain aspects of our water system that may be of interest.",
-  "Key outcomes summarize scenario results over a 100-year period. Annual variation in outcomes can be explored with the DATA IN DEPTH view and in the GET DATA section.",
-  "The hydroclimates used in scenarios approximate the range of historical and potential future conditions that our system may experience. They do not represent historical observations or predicted future conditions according to climate models.",
-  "Estimates of water deliveries to locations of interest with small water demands may be less reliable than delivery estimates for water users that receive larger volumes.",
-  "The outcomes of CalSim scenarios are best interpreted in a comparative manner \u2014 evaluating how outcomes change relative to current operations (as a baseline) is more appropriate than assessing the specific outcomes of any particular scenario.",
-] as const
+import { CAVEATS } from "../content"
 
 export default function BeforeYouBeginPanel() {
   const theme = useTheme()

--- a/apps/main/app/features/scenarioExplorer/getStarted/panels/ChooseScenariosPanel.tsx
+++ b/apps/main/app/features/scenarioExplorer/getStarted/panels/ChooseScenariosPanel.tsx
@@ -4,6 +4,7 @@ import { Typography, useTheme } from "@repo/ui/mui"
 import { BarredColumns } from "@repo/ui"
 import PanelShell from "./PanelShell"
 import PanelHeading from "./PanelHeading"
+import { SCENARIO_QUESTIONS } from "../content"
 
 export default function ChooseScenariosPanel() {
   const theme = useTheme()
@@ -17,23 +18,10 @@ export default function ChooseScenariosPanel() {
       />
 
       <BarredColumns
-        items={[
-          {
-            title: "How is my water interest doing now?",
-            description:
-              "This is the current operations scenario under the historical hydroclimate, which serves as a baseline for comparison.",
-          },
-          {
-            title: "How could alternative strategies impact my water interest?",
-            description:
-              "Select one or more scenarios to compare against the current operations scenario under the historical hydroclimate.",
-          },
-          {
-            title: "How does climate change shift the picture?",
-            description:
-              "Select scenarios that represent how current operations and alternative strategies perform under alternative hydroclimates.",
-          },
-        ]}
+        items={SCENARIO_QUESTIONS.map(({ title, description }) => ({
+          title,
+          description,
+        }))}
         color={theme.palette.common.white}
         columnGap={theme.space.section.xl}
         sx={{ mb: theme.space.section.lg }}

--- a/apps/main/app/features/scenarioExplorer/getStarted/panels/HydroclimateFuturesPanel.tsx
+++ b/apps/main/app/features/scenarioExplorer/getStarted/panels/HydroclimateFuturesPanel.tsx
@@ -1,37 +1,10 @@
 "use client"
 
 import { Box, Typography, useTheme } from "@repo/ui/mui"
-import { InfoCard } from "@repo/ui"
+import { InfoCard, InfoCardGrid } from "@repo/ui"
 import PanelShell from "./PanelShell"
 import PanelHeading from "./PanelHeading"
-
-const HYDROCLIMATES = [
-  {
-    title: "Historical hydroclimate (baseline)",
-    description:
-      "Temperature, precipitation, and streamflow patterns reflect historical conditions",
-  },
-  {
-    title: "Moderate-dry climate risk",
-    description:
-      "Warmer and slightly drier conditions (\u22121% runoff change) - 50th percentile level of concern",
-  },
-  {
-    title: "Moderate-wet climate risk",
-    description:
-      "Warmer and wetter conditions (+7% runoff change) - 44th percentile level of concern",
-  },
-  {
-    title: "High climate risk",
-    description:
-      "Warmer and much drier conditions (\u22127% runoff change) - 95th percentile level of concern",
-  },
-  {
-    title: "Extreme climate risk",
-    description:
-      "Much warmer and extremely drier conditions (\u221221% runoff change) - 99th percentile level of concern",
-  },
-] as const
+import { HYDROCLIMATES } from "../content"
 
 export default function HydroclimateFuturesPanel() {
   const theme = useTheme()
@@ -65,25 +38,17 @@ export default function HydroclimateFuturesPanel() {
         </Typography>
       </Box>
 
-      <Box
-        sx={{
-          display: "grid",
-          gridTemplateColumns: "repeat(5, 1fr)",
-          alignItems: "stretch",
-          columnGap: theme.space.section.sm,
-          rowGap: sp.lg,
-        }}
-      >
-        {HYDROCLIMATES.map(({ title, description }, i) => (
+      <InfoCardGrid columns={5}>
+        {HYDROCLIMATES.map(({ title, description, dimmed }) => (
           <InfoCard
             key={title}
             title={title}
             description={description}
-            dimmed={i === 2 || i === 4}
+            dimmed={dimmed}
             variant="onDark"
           />
         ))}
-      </Box>
+      </InfoCardGrid>
     </PanelShell>
   )
 }

--- a/apps/main/app/features/scenarioExplorer/getStarted/panels/InterpretingOutcomesPanel.tsx
+++ b/apps/main/app/features/scenarioExplorer/getStarted/panels/InterpretingOutcomesPanel.tsx
@@ -4,39 +4,7 @@ import { Box, Typography, useTheme } from "@repo/ui/mui"
 import { LinedList } from "@repo/ui"
 import PanelShell from "./PanelShell"
 import PanelHeading from "./PanelHeading"
-
-const VIZ_TOOLS: ReadonlyArray<{
-  title: string
-  description: string
-  dimmed?: boolean
-}> = [
-  {
-    title: "Map view",
-    description:
-      "Displays how outcomes vary across locations of interest and reveals spatial patterns in outcomes.",
-  },
-  {
-    title: "Distribution viewer",
-    description:
-      "Highlights how outcomes vary across key outcomes and among different locations of interest and communities, revealing who benefits and who is most impacted.",
-  },
-  {
-    title: "Radar chart",
-    description:
-      "Shows how outcomes vary within a scenario and enables comparisons across scenarios, highlighting commonalities, differences, and trade-offs.",
-  },
-  {
-    title: "Scatterplot",
-    description:
-      "Compares scenarios at the system level to reveal the relative effects of operational decisions and climate change on outcomes.",
-    dimmed: true,
-  },
-  {
-    title: "Heatmaps",
-    description:
-      "Show how scenarios perform across increasing levels of climate stress, highlighting which management strategies are most resilient or vulnerable to climate impacts.",
-  },
-]
+import { INTERPRETING_LENSES, VIZ_TOOLS } from "../content"
 
 export default function InterpretingOutcomesPanel() {
   const theme = useTheme()
@@ -65,23 +33,10 @@ export default function InterpretingOutcomesPanel() {
             strategies and hydroclimate conditions affect:
           </Typography>
           <LinedList
-            items={[
-              {
-                label: "Trade-offs",
-                description:
-                  "How outcomes improve or decline together across scenarios",
-              },
-              {
-                label: "Equity",
-                description:
-                  "How benefits and impacts are distributed across outcomes and locations of interest",
-              },
-              {
-                label: "Resilience",
-                description:
-                  "How outcomes change under increasing levels of climate stress",
-              },
-            ]}
+            items={INTERPRETING_LENSES.map(({ label, description }) => ({
+              label,
+              description,
+            }))}
             color={theme.palette.common.white}
             arrows={false}
             labelVariant="body2"

--- a/apps/main/app/features/scenarioExplorer/getStarted/panels/KeyOutcomesPanel.tsx
+++ b/apps/main/app/features/scenarioExplorer/getStarted/panels/KeyOutcomesPanel.tsx
@@ -1,70 +1,13 @@
 "use client"
 
 import { useState } from "react"
-import { Box, useTheme } from "@repo/ui/mui"
-import { InfoCard, MobileModal } from "@repo/ui"
+import { useTheme } from "@repo/ui/mui"
+import { InfoCard, InfoCardGrid, MobileModal } from "@repo/ui"
 import PanelShell from "./PanelShell"
 import PanelHeading from "./PanelHeading"
 import TierTooltipContent from "../../../tooltips/TierTooltipContent"
 import { getOutcomeName, type OutcomeCode } from "../../../../content/outcomes"
-
-const KEY_OUTCOMES: ReadonlyArray<{
-  outcomeCode: OutcomeCode
-  title: string
-  description: string
-}> = [
-  {
-    outcomeCode: "CWS_DEL",
-    title: "Community water deliveries",
-    description:
-      "Reliability of water supplies to communities to satisfy essential drinking water needs",
-  },
-  {
-    outcomeCode: "AG_REV",
-    title: "Agricultural revenue",
-    description:
-      "Economic productivity of agricultural crops based on water availability",
-  },
-  {
-    outcomeCode: "ENV_FLOWS",
-    title: "Environmental flows",
-    description:
-      "Seasonal patterns of river flows needed to support healthy ecosystems",
-  },
-  {
-    outcomeCode: "DELTA_ECO",
-    title: "Delta estuary ecology",
-    description:
-      "Seasonal patterns of flows needed to support the health of the Bay Delta estuary",
-  },
-  {
-    outcomeCode: "WRC_SALMON_AB",
-    title: "Winter-run salmon",
-    description:
-      "Population status of Sacramento River winter-run Chinook salmon",
-  },
-  {
-    outcomeCode: "FW_DELTA_USES",
-    title: "Freshwater for in-Delta uses",
-    description:
-      "Availability of freshwater in the Delta to support local communities and farms",
-  },
-  {
-    outcomeCode: "FW_EXP",
-    title: "Freshwater for Delta exports",
-    description: "Availability of freshwater for export to other regions",
-  },
-  {
-    outcomeCode: "RES_STOR",
-    title: "Reservoir storage",
-    description: "Levels of water stored in major reservoirs",
-  },
-  {
-    outcomeCode: "GW_STOR",
-    title: "Groundwater storage",
-    description: "Amount and trends of water stored in groundwater basins",
-  },
-]
+import { KEY_OUTCOMES } from "../content"
 
 export default function KeyOutcomesPanel() {
   const theme = useTheme()
@@ -81,15 +24,7 @@ export default function KeyOutcomesPanel() {
           lead="The results of each scenario are summarized by nine key outcomes:"
         />
 
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(3, 1fr)",
-            alignItems: "stretch",
-            columnGap: theme.space.section.sm,
-            rowGap: theme.space.section.sm,
-          }}
-        >
+        <InfoCardGrid columns={3} rowGap={theme.space.section.sm}>
           {KEY_OUTCOMES.map(({ outcomeCode, title, description }) => (
             <InfoCard
               key={outcomeCode}
@@ -100,7 +35,7 @@ export default function KeyOutcomesPanel() {
               ariaLabel={`${title}: open full definition and outcome levels`}
             />
           ))}
-        </Box>
+        </InfoCardGrid>
       </PanelShell>
 
       <MobileModal

--- a/apps/main/app/features/scenarioExplorer/getStarted/panels/PanelFrame.tsx
+++ b/apps/main/app/features/scenarioExplorer/getStarted/panels/PanelFrame.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { type ReactNode } from "react"
+import { Box, useTheme, type SxProps, type Theme } from "@repo/ui/mui"
+
+interface PanelFrameProps {
+  children: ReactNode
+  /** Styles applied to the inner rounded surface (e.g. background, padding,
+   *  min-height, centering). The frame inset and corner radius are fixed. */
+  innerSx?: SxProps<Theme>
+  /** Styles applied to the outer inset box. Use to override defaults such as
+   *  `pointerEvents` (e.g. the tier animation disables them while the map is
+   *  interactive). The inset paddings can be overridden here too. */
+  outerSx?: SxProps<Theme>
+}
+
+/** Shared inset + rounded-corner wrapper for Get Started sections.
+ *  The outer box holds the inset. The inner box holds the rounded corners.
+ *  Used by `PanelShell` (content cards) and by the tier animation section.
+ *  Radius and inset come from `theme.layout.panel` */
+export default function PanelFrame({
+  children,
+  innerSx,
+  outerSx,
+}: PanelFrameProps) {
+  const theme = useTheme()
+  return (
+    <Box
+      sx={{
+        pointerEvents: "auto",
+        px: theme.layout.panel.insetX,
+        py: theme.layout.panel.insetY,
+        ...((outerSx as object) ?? {}),
+      }}
+    >
+      <Box
+        sx={{
+          borderRadius: theme.layout.panel.radius,
+          overflow: "hidden",
+          ...((innerSx as object) ?? {}),
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  )
+}

--- a/apps/main/app/features/scenarioExplorer/getStarted/panels/PanelShell.tsx
+++ b/apps/main/app/features/scenarioExplorer/getStarted/panels/PanelShell.tsx
@@ -1,56 +1,41 @@
 "use client"
 
 import { type ReactNode } from "react"
-import { Box, useTheme } from "@repo/ui/mui"
+import { useTheme } from "@repo/ui/mui"
+import PanelFrame from "./PanelFrame"
 import { getStartedViewportCardHeightCss } from "../getStartedViewport"
 
 interface PanelShellProps {
   children: ReactNode
   /** Card background colour (the rounded surface) */
   background: string
-  /** Optional frame background. Defaults to transparent so the frame blends
-   *  into the scroll container. Pass a colour to cover content behind
-   *  (e.g. the persistent map when `mapMode === "get-started"`). */
-  frameBackground?: string
-  /** Inner min-height (default: 100vh) */
+  /** Inner min-height (default: viewport-fit card height) */
   minHeight?: string | number
 }
 
 /** Rounded-panel shell shared by every Get Started content panel.
- *  Frame (outer) holds the inset. Card (inner) holds the rounded corners.
- *  Radius + inset come from `theme.layout.panel` */
+ *  Wraps `PanelFrame` (inset + radius) and adds the card surface:
+ *  background, min-height, padding, and vertical centering. */
 export default function PanelShell({
   children,
   background,
-  frameBackground,
   minHeight,
 }: PanelShellProps) {
   const theme = useTheme()
   const resolvedMinHeight = minHeight ?? getStartedViewportCardHeightCss(theme)
   return (
-    <Box
-      sx={{
-        pointerEvents: "auto",
-        backgroundColor: frameBackground ?? "transparent",
-        px: theme.layout.panel.insetX,
-        py: theme.layout.panel.insetY,
+    <PanelFrame
+      innerSx={{
+        backgroundColor: background,
+        minHeight: resolvedMinHeight,
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        px: theme.space.panel.padding,
+        py: theme.space.panel.padding,
       }}
     >
-      <Box
-        sx={{
-          backgroundColor: background,
-          borderRadius: theme.layout.panel.radius,
-          overflow: "hidden",
-          minHeight: resolvedMinHeight,
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          px: theme.space.panel.padding,
-          py: theme.space.panel.padding,
-        }}
-      >
-        {children}
-      </Box>
-    </Box>
+      {children}
+    </PanelFrame>
   )
 }

--- a/apps/main/app/features/scenarioExplorer/getStarted/panels/WaterIssuesPanel.tsx
+++ b/apps/main/app/features/scenarioExplorer/getStarted/panels/WaterIssuesPanel.tsx
@@ -1,43 +1,11 @@
 "use client"
 
-import { Box, Typography, useTheme } from "@repo/ui/mui"
-import { InfoCard } from "@repo/ui"
+import { Typography, useTheme } from "@repo/ui/mui"
+import { InfoCard, InfoCardGrid } from "@repo/ui"
 import PanelShell from "./PanelShell"
 import PanelHeading from "./PanelHeading"
 import { usePanelRoute } from "../../../../hooks/usePanelRoute"
-
-const WATER_ISSUE_THEMES = [
-  {
-    title: "Community water systems",
-    description:
-      "Whether people and communities can reliably access safe drinking water for daily life, health, and essential services",
-    themeKey: "cws",
-  },
-  {
-    title: "Farms and groundwater",
-    description:
-      "Whether agricultural water deliveries can sustain food production, while preventing over-draft of groundwater basins",
-    themeKey: "ag_gw",
-  },
-  {
-    title: "Rivers, salmon and the Delta ecosystem",
-    description:
-      "Whether rivers, salmon, and the Delta estuary receive the flows they need to thrive",
-    themeKey: "eco",
-  },
-  {
-    title: "The Delta as a living place",
-    description:
-      "Whether the Delta is a place where communities, farms, and ecosystems coexist and thrive",
-    themeKey: "delta",
-  },
-  {
-    title: "Operations and impacts",
-    description:
-      "How management decisions affect trade-offs, equity and resilience",
-    themeKey: "governance",
-  },
-] as const
+import { WATER_ISSUE_THEMES } from "../content"
 
 export default function WaterIssuesPanel() {
   const theme = useTheme()
@@ -51,29 +19,18 @@ export default function WaterIssuesPanel() {
         lead="COEQWAL scenarios are designed to address key water challenges across California, including:"
       />
 
-      <Box
-        sx={{
-          display: "grid",
-          gridTemplateColumns: "repeat(5, 1fr)",
-          alignItems: "stretch",
-          columnGap: theme.space.section.sm,
-          rowGap: sp.lg,
-        }}
-      >
-        {WATER_ISSUE_THEMES.map(({ title, description, themeKey }) => {
-          const active = themeKey !== "governance"
-          return (
-            <InfoCard
-              key={themeKey}
-              title={title}
-              description={description}
-              onClick={active ? () => openThemePanel(themeKey) : undefined}
-              dimmed={!active}
-              variant="onDark"
-            />
-          )
-        })}
-      </Box>
+      <InfoCardGrid columns={5}>
+        {WATER_ISSUE_THEMES.map(({ title, description, themeKey, dimmed }) => (
+          <InfoCard
+            key={themeKey}
+            title={title}
+            description={description}
+            onClick={dimmed ? undefined : () => openThemePanel(themeKey)}
+            dimmed={dimmed}
+            variant="onDark"
+          />
+        ))}
+      </InfoCardGrid>
 
       <Typography variant="body2" color="text.secondary" sx={{ mt: sp.lg }}>
         Click on each water issue to learn more.

--- a/apps/main/app/sections/intro/WaterThemesPanel.tsx
+++ b/apps/main/app/sections/intro/WaterThemesPanel.tsx
@@ -10,6 +10,7 @@ import { Box, Typography, useTheme } from "@repo/ui/mui"
 import {
   NavArrow,
   InfoCard,
+  InfoCardGrid,
   ScrollToButton,
   resolveRadius,
   resolveInset,
@@ -470,13 +471,9 @@ function WaterThemesPanelContent({
         </motion.div>
 
         {/* Five theme cards - horizontal grid */}
-        <Box
+        <InfoCardGrid
+          columns={5}
           sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(5, 1fr)",
-            alignItems: "stretch",
-            columnGap: theme.space.section.sm,
-            rowGap: theme.space.component.lg,
             // Short-viewport layout: the text block above is anchored
             // to the headline's top instead of being vertically
             // centered, which removes the natural breathing room
@@ -518,7 +515,7 @@ function WaterThemesPanelContent({
               </InfoCard>
             )
           })}
-        </Box>
+        </InfoCardGrid>
       </Box>
 
       {/* Scroll-down arrow, matches the VideoHero and About panels.

--- a/packages/ui/src/components/common/InfoCardGrid.tsx
+++ b/packages/ui/src/components/common/InfoCardGrid.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { type ReactNode } from "react"
+import { Box, useTheme, type SxProps, type Theme } from "@mui/material"
+
+export interface InfoCardGridProps {
+  /** Number of equal-width columns (CSS grid `repeat(columns, 1fr)`). */
+  columns: number
+  children: ReactNode
+  /** Horizontal gap between columns. Defaults to `theme.space.section.sm`. */
+  columnGap?: string | number
+  /** Vertical gap between rows. Defaults to `theme.space.component.lg`. */
+  rowGap?: string | number
+  sx?: SxProps<Theme>
+}
+
+/** Equal-column grid wrapper for `InfoCard` rows. Centralizes the grid
+ *  layout shared by the get-started and intro card sections. */
+export function InfoCardGrid({
+  columns,
+  children,
+  columnGap,
+  rowGap,
+  sx,
+}: InfoCardGridProps) {
+  const theme = useTheme()
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${columns}, 1fr)`,
+        alignItems: "stretch",
+        columnGap: columnGap ?? theme.space.section.sm,
+        rowGap: rowGap ?? theme.space.component.lg,
+        ...((sx as object) ?? {}),
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
+
+export default InfoCardGrid

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -58,6 +58,8 @@ export { LinedList } from "./common/LinedList"
 export type { LinedListProps, LinedListItem } from "./common/LinedList"
 export { InfoCard } from "./common/InfoCard"
 export type { InfoCardProps } from "./common/InfoCard"
+export { InfoCardGrid } from "./common/InfoCardGrid"
+export type { InfoCardGridProps } from "./common/InfoCardGrid"
 export { BarredColumns } from "./common/BarredColumns"
 export type {
   BarredColumnsProps,


### PR DESCRIPTION
**Summary**
- Added `InfoCardGrid`, an equal-column grid wrapper, to `@repo/ui` and export it from the barrel.
- Consolidated the get-started panels onto the shared `InfoCardGrid` layout via a new `PanelFrame`, plus extracted panel `content.ts`.
- Applied the same layout to the intro `WaterThemesPanel`.